### PR TITLE
Added --reverse option to generate valid OpenAPI3 specs by retaining …

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function filter(obj,options) {
         }
         for (let tag of options.tags) {
             if (obj[key] && obj[key][tag]) {
-                if (options.inverse) {
+                if (options.inverse || options.reverse) {
                     if (options.strip) {
                         delete obj[key][tag];
                     }
@@ -58,7 +58,35 @@ function filter(obj,options) {
         }
         if (!filtered.paths) filtered.paths = {};
     }
-    return (options.inverse ? filtered : src);
+    let reversed = {}
+    if (options.reverse) {
+        reversed = filtered
+        if (src.openapi && !reversed.openapi) {
+            reversed.openapi = src.openapi
+        }
+        if (src.info && !reversed.info) {
+            reversed.info = src.info
+        }
+        if (src.externalDocs && !reversed.externalDocs) {
+            reversed.externalDocs = src.externalDocs
+        }
+        if (src.servers && !reversed.servers) {
+            reversed.servers = src.servers
+        }
+        if (src.tags && !reversed.tags) {
+            reversed.tags = src.tags
+        }
+        if (src['x-tagGroups'] && !reversed['x-tagGroups']) {
+            reversed['x-tagGroups'] = src['x-tagGroups']
+        }
+        if (src.paths && !reversed.paths) {
+            reversed.paths = src.paths
+        }
+        if (src.components && !reversed.components) {
+            reversed.components = src.components
+        }
+    }
+    return (options.inverse ? filtered : options.reverse? reversed : src);
 }
 
 module.exports = {

--- a/openapi-filter.js
+++ b/openapi-filter.js
@@ -7,13 +7,16 @@ const yaml = require('js-yaml');
 const yargs = require('yargs');
 const openapiFilter = require('./index.js');
 
-let argv = require('yargs')
+let argv = yargs
     .usage('Usage: openapi-filter [options] {infile} [{outfile}]')
     .demand(1)
     .strict()
     .boolean('inverse')
     .describe('inverse','output filtered elements only')
     .alias('i','inverse')
+    .boolean('reverse')
+    .describe('reverse','generate valid doc by retaining filtered elements; applies to OpenAPI3 only;')
+    .alias('r', 'reverse')
     .array('tags')
     .alias('t','tags')
     .describe('tags','tags to filter by')


### PR DESCRIPTION
- Added --reverse option to generate valid OpenAPI3 specs by retaining filtered elements only
- Applies to OpenAPI3 only
- If there is a filtered version of the element, that is used; otherwise the original source version is used as is